### PR TITLE
v0.4

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - run: bun test
+      - run: bun run build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TanstackDB SurrealDB Collections
 
-Add Offline / Local First Caching & Syncing to your SurrealDB app with TanstackDB and Loro (CRDTs). Designed for SurrealDB v3.beta-1 and SurrealDB JS SDK v2 (and above).
+Add Offline / Local First Caching & Syncing to your SurrealDB app with TanstackDB and Loro (CRDTs). Designed for SurrealDB v3 and SurrealDB JS SDK v2.
 
 - Local / Offline first applications with TanstackDB and Loro
 - High performance with Low resource consumption

--- a/bun.lock
+++ b/bun.lock
@@ -8,15 +8,20 @@
         "loro-crdt": "^1.10.6",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.3.14",
-        "@tanstack/query-db-collection": "^1.0.22",
-        "@tanstack/react-db": "latest",
-        "@tanstack/react-query": "latest",
+        "@biomejs/biome": "^2.3.15",
+        "@standard-schema/spec": "^1.0.0",
+        "@tanstack/db": "^0.5.26",
+        "@tanstack/query-core": "^5.0.0",
+        "@tanstack/query-db-collection": "^1.0.23",
+        "@types/bun": "^1.3.2",
         "surrealdb": "2.0.0-alpha.17",
         "tsup": "^8.5.1",
       },
       "peerDependencies": {
-        "@tanstack/db": "^0.5.25",
+        "@standard-schema/spec": "^1.0.0",
+        "@tanstack/db": "^0.5.26",
+        "@tanstack/query-core": "^5.0.0",
+        "@tanstack/query-db-collection": "^1.0.23",
         "surrealdb": "2.0.0-alpha.17",
       },
     },
@@ -162,11 +167,11 @@
 
     "@tanstack/query-db-collection": ["@tanstack/query-db-collection@1.0.23", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@tanstack/db": "0.5.26" }, "peerDependencies": { "@tanstack/query-core": "^5.0.0", "typescript": ">=4.7" } }, "sha512-2xVUvfOuW1wVx8zS5vgsy1Wt45P+3Nt3bGnGqWWqynLrU4guIM1V+VvoBaFI5ZleaIc0xZMpPS3fwIALh1OggA=="],
 
-    "@tanstack/react-db": ["@tanstack/react-db@0.1.70", "", { "dependencies": { "@tanstack/db": "0.5.26", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-OISznZtrjkbyktbAoj/2KyFf9Xv9vr7JfkQO4od4eH76X+vQXYZkVgs2IV5sM27YNatOyf1Or4BEELIbyYB4xA=="],
-
-    "@tanstack/react-query": ["@tanstack/react-query@5.90.21", "", { "dependencies": { "@tanstack/query-core": "5.90.20" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg=="],
+    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
 
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
@@ -179,6 +184,8 @@
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
     "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
 
@@ -268,8 +275,6 @@
 
     "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
 
-    "react": ["react@19.2.3", "", {}, "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA=="],
-
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
@@ -318,7 +323,7 @@
 
     "ufo": ["ufo@1.6.1", "", {}, "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="],
 
-    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "uuidv7": ["uuidv7@1.0.2", "", { "bin": { "uuidv7": "cli.js" } }, "sha512-8JQkH4ooXnm1JCIhqTMbtmdnYEn6oKukBxHn1Ic9878jMkL7daTI7anTExfY18VRCX7tcdn5quzvCb6EWrR8PA=="],
 

--- a/examples/products.ts
+++ b/examples/products.ts
@@ -3,8 +3,8 @@ import { surrealCollectionOptions } from '../dist';
 import { RecordId, Surreal, eq, or } from 'surrealdb';
 
 import { createCollection } from '@tanstack/db';
-import { useLiveQuery } from '@tanstack/svelte-db';
-import { QueryClient } from '@tanstack/svelte-query';
+import { useLiveQuery } from '@tanstack/react-db';
+import { QueryClient } from '@tanstack/react-query';
 
 const db = new Surreal();
 const queryClient = new QueryClient();

--- a/examples/syncMode.ts
+++ b/examples/syncMode.ts
@@ -3,8 +3,8 @@ import { surrealCollectionOptions, type SurrealSubset } from '../dist';
 import { eq, Surreal } from 'surrealdb';
 
 import { createCollection } from '@tanstack/db';
-import { QueryClient } from '@tanstack/svelte-query'; // can also be '@tanstack/react-query' or '@tanstack/svelte-query'
-import { useLiveQuery } from '@tanstack/svelte-db';
+import { QueryClient } from '@tanstack/react-query'; // can also be '@tanstack/svelte-query' etc.
+import { useLiveQuery } from '@tanstack/react-db';
 
 const db = new Surreal();
 const queryClient = new QueryClient();

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
 	"name": "@foretag/tanstack-db-surrealdb",
-	"version": "0.3.9",
+	"version": "0.4.0",
 	"license": "MIT",
 	"exports": "./src/index.ts"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@foretag/tanstack-db-surrealdb",
 	"description": "Add Offline / Local First Caching & Syncing to your SurrealDB app with TanstackDB and Loro (CRDTs)",
-	"version": "0.3.9",
+	"version": "0.4.0",
 	"files": [
 		"dist"
 	],

--- a/package.json
+++ b/package.json
@@ -44,13 +44,18 @@
 	},
 	"peerDependencies": {
 		"@tanstack/db": "^0.5.26",
+		"@tanstack/query-core": "^5.0.0",
+		"@tanstack/query-db-collection": "^1.0.23",
+		"@standard-schema/spec": "^1.0.0",
 		"surrealdb": "2.0.0-alpha.17"
 	},
 	"devDependencies": {
+		"@types/bun": "^1.3.2",
 		"@biomejs/biome": "^2.3.15",
+		"@standard-schema/spec": "^1.0.0",
+		"@tanstack/db": "^0.5.26",
+		"@tanstack/query-core": "^5.0.0",
 		"@tanstack/query-db-collection": "^1.0.23",
-		"@tanstack/react-db": "latest",
-		"@tanstack/react-query": "latest",
 		"surrealdb": "2.0.0-alpha.17",
 		"tsup": "^8.5.1"
 	}

--- a/src/id.ts
+++ b/src/id.ts
@@ -38,7 +38,8 @@ export const normalizeRecordIdLikeValue = (value: unknown): unknown => {
 	const unquoted = stripOuterQuotes(trimmed);
 
 	const parsed =
-		parseRecordIdString(unquoted) ?? parseRecordIdString(trimmed);
+		parseRecordIdString(unquoted) ??
+		(unquoted === trimmed ? undefined : parseRecordIdString(trimmed));
 	if (parsed) return parsed;
 
 	// Keep original value shape if it isn't record-id-like

--- a/tests/crdt.test.ts
+++ b/tests/crdt.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'bun:test';
+import { RecordId } from 'surrealdb';
+
+import { manageTable } from '../src/table';
+
+type Row = {
+	id: string | RecordId;
+	name?: string;
+	sync_deleted?: boolean;
+	updated_at?: Date | number | string;
+};
+
+describe('CRDT behavior (useLoro=true)', () => {
+	it('applies sync filter, update clock, and tombstone delete', async () => {
+		const queries: Array<{ sql: string; params: Record<string, unknown> }> = [];
+		const updates: Array<{ id: unknown; payload: Record<string, unknown> }> = [];
+		const upserts: Array<{ id: unknown; payload: Record<string, unknown> }> = [];
+		const deletes: unknown[] = [];
+
+		const db = {
+			query: async (sql: string, params: Record<string, unknown>) => {
+				queries.push({ sql, params });
+				return [[]];
+			},
+			update: (id: unknown) => ({
+				merge: async (payload: Record<string, unknown>) => {
+					updates.push({ id, payload });
+				},
+			}),
+			upsert: (id: unknown) => ({
+				merge: async (payload: Record<string, unknown>) => {
+					upserts.push({ id, payload });
+				},
+			}),
+			delete: async (id: unknown) => {
+				deletes.push(id);
+			},
+			create: () => ({
+				content: async () => {},
+			}),
+			insert: async () => {},
+			isFeatureSupported: () => false,
+			live: () => ({
+				where: () => ({
+					subscribe: () => {},
+					kill: async () => {},
+				}),
+			}),
+		};
+
+		const table = manageTable<Row>(db as never, true, { name: 'products' });
+		const rid = new RecordId('products', '1');
+
+		await table.listAll();
+		await table.update(rid, { name: 'desk' });
+		await table.softDelete(rid);
+
+		expect(queries[0]?.sql).toContain('WHERE $where');
+		expect(queries[0]?.params.where).toBeTruthy();
+
+		expect(updates.length).toBe(1);
+		expect(updates[0]?.payload.sync_deleted).toBe(false);
+		expect(typeof updates[0]?.payload.updated_at).toBe('number');
+
+		expect(upserts.length).toBe(1);
+		expect(upserts[0]?.payload.sync_deleted).toBe(true);
+		expect(typeof upserts[0]?.payload.updated_at).toBe('number');
+
+		expect(deletes.length).toBe(0);
+	});
+});

--- a/tests/id.test.ts
+++ b/tests/id.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'bun:test';
+import { RecordId } from 'surrealdb';
+
+import {
+	normalizeRecordIdLikeFields,
+	normalizeRecordIdLikeValue,
+	stripOuterQuotes,
+	toRecordId,
+	toRecordIdString,
+} from '../src/id';
+
+describe('id helpers', () => {
+	it('strips matching single or double quotes only', () => {
+		expect(stripOuterQuotes("'products:1'")).toBe('products:1');
+		expect(stripOuterQuotes('"products:1"')).toBe('products:1');
+		expect(stripOuterQuotes('products:1')).toBe('products:1');
+	});
+
+	it('normalizes record-id-like strings and leaves other values untouched', () => {
+		const normalized = normalizeRecordIdLikeValue('products:1');
+		expect(normalized instanceof RecordId).toBe(true);
+		expect((normalized as RecordId).toString()).toBe('products:⟨1⟩');
+
+		const plain = normalizeRecordIdLikeValue('hello');
+		expect(plain).toBe('hello');
+	});
+
+	it('normalizes record-id-like fields in an object', () => {
+		const out = normalizeRecordIdLikeFields({
+			id: 'products:1',
+			name: 'desk',
+		});
+		expect(out.id instanceof RecordId).toBe(true);
+		expect(out.name).toBe('desk');
+	});
+
+	it('converts RecordId and strings into table-scoped RecordIds', () => {
+		const fromPlain = toRecordId('products', '1');
+		expect(fromPlain.toString()).toBe('products:⟨1⟩');
+
+		const fromPrefixed = toRecordId('products', 'products:1');
+		expect(fromPrefixed.toString()).toBe('products:⟨1⟩');
+
+		const rid = new RecordId('products', '2');
+		expect(toRecordId('products', rid)).toBe(rid);
+	});
+
+	it('normalizes RecordId|string to stable string form', () => {
+		expect(toRecordIdString("'products:1'")).toBe('products:1');
+		expect(toRecordIdString(new RecordId('products', '1'))).toBe(
+			'products:⟨1⟩',
+		);
+	});
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'bun:test';
+import { RecordId } from 'surrealdb';
+
+import { surrealCollectionOptions } from '../src/index';
+
+type Product = {
+	id: string | RecordId;
+	name: string;
+};
+
+const createOptions = () =>
+	surrealCollectionOptions<Product>({
+		db: {} as never,
+		queryClient: {} as never,
+		queryKey: ['products'],
+		table: { name: 'products' },
+	});
+
+describe('surrealCollectionOptions schema', () => {
+	it('generates temp ids when id is missing', () => {
+		const opts = createOptions();
+		const result = opts.schema['~standard'].validate({
+			name: 'desk',
+		}) as { value: Record<string, unknown> };
+
+		expect(result.value.name).toBe('desk');
+		expect(result.value.id instanceof RecordId).toBe(true);
+		const key = (result.value.id as Record<string, unknown>).id;
+		expect(typeof key).toBe('string');
+		expect((key as string).startsWith('__temp__')).toBe(true);
+	});
+
+	it('normalizes record-id-like id values if provided', () => {
+		const opts = createOptions();
+		const result = opts.schema['~standard'].validate({
+			id: 'products:1',
+			name: 'desk',
+		}) as { value: Record<string, unknown> };
+
+		expect(result.value.id instanceof RecordId).toBe(true);
+		expect((result.value.id as RecordId).toString()).toBe('products:⟨1⟩');
+	});
+
+	it('returns validation issues for non-object inserts', () => {
+		const opts = createOptions();
+		const result = opts.schema['~standard'].validate(
+			'not-an-object',
+		) as { issues?: Array<{ message: string }> };
+
+		expect(result.issues?.[0]?.message).toBe(
+			'Insert data must be an object.',
+		);
+	});
+});

--- a/tests/table.test.ts
+++ b/tests/table.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from 'bun:test';
+import { eq, RecordId } from 'surrealdb';
+
+import { manageTable } from '../src/table';
+
+type Product = {
+	id: string | RecordId;
+	name?: string;
+	sync_deleted?: boolean;
+	updated_at?: Date | number | string;
+};
+
+const createDbMock = () => {
+	const state: {
+		queries: Array<{ sql: string; params: Record<string, unknown> }>;
+		createdContent: unknown[];
+		inserted: unknown[];
+		updated: Array<{ id: unknown; payload: unknown }>;
+		deleted: unknown[];
+		upserted: Array<{ id: unknown; payload: unknown }>;
+		liveWhere: unknown[];
+		liveKillCount: number;
+		supportLiveQueries: boolean;
+		liveSubscriber?: (msg: unknown) => void;
+	} = {
+		queries: [],
+		createdContent: [],
+		inserted: [],
+		updated: [],
+		deleted: [],
+		upserted: [],
+		liveWhere: [],
+		liveKillCount: 0,
+		supportLiveQueries: true,
+	};
+
+	const db = {
+		query: async (sql: string, params: Record<string, unknown>) => {
+			state.queries.push({ sql, params });
+			return [[]];
+		},
+		create: () => ({
+			content: async (payload: unknown) => {
+				state.createdContent.push(payload);
+			},
+		}),
+		insert: async (_table: unknown, payload: unknown) => {
+			state.inserted.push(payload);
+		},
+		update: (id: unknown) => ({
+			merge: async (payload: unknown) => {
+				state.updated.push({ id, payload });
+			},
+		}),
+		delete: async (id: unknown) => {
+			state.deleted.push(id);
+		},
+		upsert: (id: unknown) => ({
+			merge: async (payload: unknown) => {
+				state.upserted.push({ id, payload });
+			},
+		}),
+		isFeatureSupported: () => state.supportLiveQueries,
+		live: () => ({
+			where: (whereExpr: unknown) => {
+				state.liveWhere.push(whereExpr);
+				return {
+					subscribe: (cb: (msg: unknown) => void) => {
+						state.liveSubscriber = cb;
+					},
+					kill: async () => {
+						state.liveKillCount += 1;
+					},
+				};
+			},
+		}),
+	};
+
+	return { db, state };
+};
+
+describe('manageTable', () => {
+	it('builds listAll query and subset query correctly', async () => {
+		const { db, state } = createDbMock();
+		const table = manageTable<Product>(db as never, false, {
+			name: 'products',
+			fields: ['id', 'name'],
+			where: eq('active', true),
+		});
+
+		await table.listAll();
+		await table.loadSubset({
+			orderBy: ['name DESC', 'id ASC'],
+			limit: 10,
+			offset: 5,
+		});
+
+		expect(state.queries.length).toBe(2);
+		expect(state.queries[0]?.sql).toContain('SELECT id, name FROM');
+		expect(state.queries[0]?.sql).toContain('WHERE $where');
+		expect(state.queries[1]?.sql).toContain('ORDER BY name DESC, id ASC');
+		expect(state.queries[1]?.sql).toContain('LIMIT $limit');
+		expect(state.queries[1]?.sql).toContain('START $offset');
+	});
+
+	it('creates with db.create when id is missing and with db.insert when id exists', async () => {
+		const { db, state } = createDbMock();
+		const table = manageTable<Product>(db as never, false, {
+			name: 'products',
+		});
+
+		await table.create({ name: 'desk' });
+		await table.create({ id: '1', name: 'chair' });
+
+		expect(state.createdContent).toEqual([{ name: 'desk' }]);
+		expect(state.inserted.length).toBe(1);
+		const inserted = state.inserted[0] as { id: RecordId; name: string };
+		expect(inserted.name).toBe('chair');
+		expect(inserted.id instanceof RecordId).toBe(true);
+		expect(inserted.id.toString()).toBe('products:⟨1⟩');
+	});
+
+	it('treats undefined id as missing and uses db.create', async () => {
+		const { db, state } = createDbMock();
+		const table = manageTable<Product>(db as never, false, {
+			name: 'products',
+		});
+
+		await table.create({ id: undefined, name: 'server-id' });
+
+		expect(state.createdContent).toEqual([{ id: undefined, name: 'server-id' }]);
+		expect(state.inserted.length).toBe(0);
+	});
+
+	it('updates and soft-deletes according to useLoro mode', async () => {
+		const { db, state } = createDbMock();
+		const rid = new RecordId('products', '1');
+
+		const nonLoro = manageTable<Product>(db as never, false, {
+			name: 'products',
+		});
+		await nonLoro.update(rid, { name: 'plain' });
+		await nonLoro.softDelete(rid);
+
+		const loro = manageTable<Product>(db as never, true, {
+			name: 'products',
+		});
+		await loro.update(rid, { name: 'loro' });
+		await loro.softDelete(rid);
+
+		expect(state.updated.length).toBe(2);
+		expect(state.deleted.length).toBe(1);
+		expect(state.upserted.length).toBe(1);
+
+		const plainUpdate = state.updated[0]?.payload as { name: string };
+		expect(plainUpdate.name).toBe('plain');
+		expect('sync_deleted' in plainUpdate).toBe(false);
+
+		const loroUpdate = state.updated[1]?.payload as {
+			name: string;
+			sync_deleted: boolean;
+			updated_at: unknown;
+		};
+		expect(loroUpdate.name).toBe('loro');
+		expect(loroUpdate.sync_deleted).toBe(false);
+		expect(typeof loroUpdate.updated_at).toBe('number');
+
+		const tombstone = state.upserted[0]?.payload as {
+			sync_deleted: boolean;
+			updated_at: unknown;
+		};
+		expect(tombstone.sync_deleted).toBe(true);
+		expect(typeof tombstone.updated_at).toBe('number');
+	});
+
+	it('subscribes to live updates and cleans up', async () => {
+		const { db, state } = createDbMock();
+		const events: Array<{ type: 'insert' | 'update' | 'delete'; row: Product }> =
+			[];
+		const table = manageTable<Product>(db as never, false, {
+			name: 'products',
+			where: eq('active', true),
+		});
+
+		const cleanup = table.subscribe((evt) => {
+			events.push(evt);
+		});
+
+		await Promise.resolve();
+		expect(state.liveWhere.length).toBe(1);
+		expect(typeof state.liveSubscriber).toBe('function');
+
+		state.liveSubscriber?.({
+			action: 'CREATE',
+			value: { id: 'products:1', name: 'desk' },
+		});
+		state.liveSubscriber?.({
+			action: 'UPDATE',
+			value: { id: 'products:1', name: 'desk v2' },
+		});
+		state.liveSubscriber?.({
+			action: 'DELETE',
+			value: { id: 'products:1' },
+		});
+		state.liveSubscriber?.({
+			action: 'KILLED',
+			value: { id: 'products:1' },
+		});
+
+		expect(events.length).toBe(3);
+		expect(events[0]?.type).toBe('insert');
+		expect(events[1]?.type).toBe('update');
+		expect(events[2]?.type).toBe('delete');
+
+		cleanup();
+		expect(state.liveKillCount).toBe(1);
+	});
+
+	it('does not open live subscription when feature is unsupported', async () => {
+		const { db, state } = createDbMock();
+		state.supportLiveQueries = false;
+
+		const table = manageTable<Product>(db as never, false, {
+			name: 'products',
+		});
+		const cleanup = table.subscribe(() => {});
+		await Promise.resolve();
+		cleanup();
+
+		expect(state.liveWhere.length).toBe(0);
+		expect(state.liveKillCount).toBe(0);
+	});
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
 		"lib": ["ESNext"],
 		"target": "ES2024",
 		"module": "ESNext",
-		"moduleResolution": "bundler"
+		"moduleResolution": "bundler",
+		"types": ["bun"]
 	}
 }


### PR DESCRIPTION
Adds:

- CI workflow for tests for PRs & Pushes
- Reworked the CRDT implementation to boost serialization performance
- Test suite to ensure stability and backports for older @tanstack/db packages where possible

Refactors:

- Pre-computed table properties as an optimisation

Removes:

- UUIDs for `id` fields